### PR TITLE
Add wisdom to gbot, fix bugs in bacon, cn and page titles, coding style improvements

### DIFF
--- a/gbot.py
+++ b/gbot.py
@@ -150,8 +150,8 @@ class commands:
         data = json.loads(resp.decode('utf8'))
         say(data['magic']['answer'])
     cmdlist ={
-        "!swag" : swag,
         "!smug" : smug,
+        "!swag" : swag,
         "!cn" : norris,
         "!bacon" : bacon,
         "!users" : listusr,

--- a/gbot.py
+++ b/gbot.py
@@ -218,7 +218,6 @@ class commands:
 
 bot = commands()
 while 1:
-    global CONNECTED
     readbuffer = readbuffer+s.recv(1024).decode("UTF-8",'ignore')
     temp = str.split(readbuffer, "\n")
     readbuffer=temp.pop( )

--- a/gbot.py
+++ b/gbot.py
@@ -118,7 +118,7 @@ class commands:
         req = urllib.request.urlopen(url)
         resp = req.read()
         joke = json.loads(resp.decode('utf8'))
-        say(unescape(joke['value']['joke']))
+        say(unescape(joke['value']['joke']).replace("  ", " "))
     def bacon(info,usrs):
         msg = info['msg'].replace(" ","")
         if(msg in usrs):

--- a/gbot.py
+++ b/gbot.py
@@ -115,8 +115,9 @@ class commands:
         joke = json.loads(resp.decode('utf8'))
         say(unescape(joke['value']['joke']))
     def bacon(info,usrs):
-        if(info['msg'].replace(" ","") in usrs):
-            say("\001ACTION gives " + info['msg'] + " a delicious strip of bacon as a gift from " + info['user'] + "! \001")
+    	msg = info['msg'].replace(" ","")
+        if(msg in usrs):
+            say("\001ACTION gives " + msg + " a delicious strip of bacon as a gift from " + info['user'] + "! \001")
         else:
             say("\001ACTION gives " + info['user'] + " a delicious strip of bacon.  \001")
     def listusr(info,users):

--- a/gbot.py
+++ b/gbot.py
@@ -149,6 +149,11 @@ class commands:
         resp = req.read()
         data = json.loads(resp.decode('utf8'))
         say(data['magic']['answer'])
+    def wisdom(info,usrs):
+        page = requests.get('http://wisdomofchopra.com/iframe.php')
+        tree = html.fromstring(page.content)
+        quote = tree.xpath('//table//td[@id="quote"]//header//h2/text()')
+        say(quote[0][1:-3])
     cmdlist ={
         "!smug" : smug,
         "!swag" : swag,
@@ -157,7 +162,8 @@ class commands:
         "!users" : listusr,
         "!btc" : btc,
         "!lenny" : lenny,
-        "!8ball" : eightball
+        "!8ball" : eightball,
+        "!wisdom" : wisdom
     }
 
     def parse(self,line):

--- a/gbot.py
+++ b/gbot.py
@@ -77,7 +77,7 @@ def say(msg):
 # get the title from a link and send it to the channel
 def getTitle(link):
     try:
-        page = requests.get(link, headers=headers)
+        page = requests.get(link, headers=headers, timeout=(5,20))
         tree = html.fromstring(page.text)
         title = tree.xpath('//title/text()')
         say("^ " + title[0].strip())

--- a/gbot.py
+++ b/gbot.py
@@ -78,6 +78,7 @@ def say(msg):
 def getTitle(link):
     try:
         page = requests.get(link, headers=headers, timeout=(5,20))
+        page.encoding = 'UTF-8'
         tree = html.fromstring(page.text)
         title = tree.xpath('//title/text()')
         say("^ " + title[0].strip())

--- a/gbot.py
+++ b/gbot.py
@@ -115,7 +115,7 @@ class commands:
         joke = json.loads(resp.decode('utf8'))
         say(unescape(joke['value']['joke']))
     def bacon(info,usrs):
-    	msg = info['msg'].replace(" ","")
+        msg = info['msg'].replace(" ","")
         if(msg in usrs):
             say("\001ACTION gives " + msg + " a delicious strip of bacon as a gift from " + info['user'] + "! \001")
         else:


### PR DESCRIPTION
This pull request contains a number of changes:
- Adds Deepak Chopra's wisdom to gbot (randomly generated quotes from Chopra's tweets as found in wisdomofchopra.com made by Tom Williamson of skepticcanary.com)
- Fixes #25 in bacon where it's received with more white-spaces when given as a gift
- Fixes #26 displaying non-latin characters by forcing UTF-8 (some characters still don't show up)
- Fixes #27 by forcing a 10 sec timeout for when trying to obtain website title
- reorders !swag with !smug in cmdlist according to coding style applied at the other commands
- Fixes #29 in chuck norris
- Fixes Syntax Warning: `gbot.py:221: SyntaxWarning: name 'CONNECTED' is assigned to before global declaration`
- Fixes conflict between testing branch replacing older pull request #24 

All changes are tested
